### PR TITLE
Removed scratch from templates where possible

### DIFF
--- a/layouts/course/section.html
+++ b/layouts/course/section.html
@@ -30,30 +30,33 @@
         </div>
 
         {{ range ( where .Sections "Type" "course_chapter" ) }}
-            {{ $.Scratch.Set "duration" 0 }}
+            {{ $totalDuration := 0 }}
             {{ range ( sort (where .Pages "Type" "video") "Date" "asc" ) }}
                 {{ with .Params.videoid }}
-                {{ $vduration_key := (printf "%s_duration" .) }}
-                {{ $.Scratch.Set $vduration_key 0 }}
 
-                {{ with getJSON (printf "https://www.googleapis.com/youtube/v3/videos?id=%s&part=contentDetails&key=%s" . $.Site.Params.ytapikey) }}
-                    {{ $duration_str := replaceRE "[MH]" "-" (replaceRE "[PTS]" "" (index .items 0 ).contentDetails.duration) }}
-                    {{ $units := split $duration_str "-" }}
+                    {{ $vduration_key := (printf "%s_duration" .) }}
+                    {{ $duration := 0}}
 
-                    {{ if isset $units 2 }}
-                        {{ $h := (int (index $units 0)) }}
-                        {{ $m := (int (index $units 1)) }}
-                        {{ $s := (int (index $units 2)) }}
-                        {{ $.Scratch.Set $vduration_key (add (add (mul $h 3600) (mul $m 60)) $s) }}
-                    {{ else if isset $units 1 }}
-                        {{ $m := (int (index $units 0)) }}
-                        {{ $s := (int (index $units 1)) }}
-                        {{ $.Scratch.Set $vduration_key (add (mul $m 60) $s) }}
-                    {{ else }}
-                        {{ $.Scratch.Set $vduration_key (int (index $units 0)) }}
+                    {{ with getJSON (printf "https://www.googleapis.com/youtube/v3/videos?id=%s&part=contentDetails&key=%s" . $.Site.Params.ytapikey) }}
+                        {{ $duration_str := replaceRE "[MH]" "-" (replaceRE "[PTS]" "" (index .items 0 ).contentDetails.duration) }}
+                        {{ $units := split $duration_str "-" }}
+
+                        {{ if isset $units 2 }}
+                            {{ $h := (int (index $units 0)) }}
+                            {{ $m := (int (index $units 1)) }}
+                            {{ $s := (int (index $units 2)) }}
+                            {{ $duration = (add (add (mul $h 3600) (mul $m 60)) $s) }}
+                        {{ else if isset $units 1 }}
+                            {{ $m := (int (index $units 0)) }}
+                            {{ $s := (int (index $units 1)) }}
+                            {{ $duration = (add (mul $m 60) $s) }}
+                        {{ else }}
+                            {{ $duration = (int (index $units 0)) }}
+                        {{ end }}
+
+                        {{ $.Scratch.Set $vduration_key $duration }}
+                        {{ $totalDuration = (add $totalDuration $duration) }}
                     {{ end }}
-                    {{ $.Scratch.Add "duration" ($.Scratch.Get $vduration_key) }}
-                {{ end }}
                 {{ end }}
             {{ end }}
 
@@ -61,9 +64,8 @@
         <!-- chapter title -->
         <div class="tiny-padding">
             <h2 id="{{ replace .Params.title " " "-" }}" class="no-margin"> {{ .Params.title }} </h2>
-            {{ $duration := ($.Scratch.Get "duration") }}
-            {{ if gt $duration 0 }}
-            <span data-font="dimmed small">Duration: {{ div $duration 60 }} min {{ mod $duration 60 }} s </span>
+            {{ if gt $totalDuration 0 }}
+            <span data-font="dimmed small">Duration: {{ div $totalDuration 60 }} min {{ mod $totalDuration 60 }} s </span>
             {{ end }}
             <p>{{ .Description | markdownify }}</p>
 
@@ -92,15 +94,15 @@
                     <!-- Video length -->
                     {{ $vduration_key := (printf "%s_duration" .Params.videoid) }}
                     {{ with $.Scratch.Get $vduration_key }}
-                        {{ $.Scratch.Set "video_length" 0 }}
+                        {{ $video_length := 0 }}
                         {{ if gt . 3600 }}
-                            {{ $.Scratch.Set "video_length" (printf "%s h %s m" (string (div . 3600)) (string (div (mod . 3600) 60))) }}
+                            {{ $video_length = (printf "%s h %s m" (string (div . 3600)) (string (div (mod . 3600) 60))) }}
                         {{ else if gt . 60 }}
-                            {{ $.Scratch.Set "video_length" (printf "%s m" (string (div . 60))) }}
+                            {{ $video_length = (printf "%s m" (string (div . 60))) }}
                         {{ else }}
-                            {{ $.Scratch.Set "video_length" (printf "%s s" (string .)) }}
+                            {{ $video_length =  (printf "%s s" (string .)) }}
                         {{ end }}
-                    <span data-font="dimmed">({{ $.Scratch.Get "video_length" }})</span>
+                    <span data-font="dimmed">({{ $video_length }})</span>
                     {{ end }}
                 </li>
                 {{ end }}

--- a/layouts/video/single.html
+++ b/layouts/video/single.html
@@ -1,13 +1,11 @@
 {{ define "head_content" }}
-
-{{ $.Scratch.Set "course_page" 0 }}
 {{ if eq .CurrentSection.Parent.Type "course" }}
-{{ $.Scratch.Set "course_page" .CurrentSection.Parent }}
+    {{ $.Scratch.Set "course_page" .CurrentSection.Parent }}
 {{ else if eq .Parent.Type "course"}}
-{{ $.Scratch.Set "course_page" .Parent }}
+    {{ $.Scratch.Set "course_page" .Parent }}
 {{ end }}
 
-{{ partial "modules/banner" ($.Scratch.Get "course_page") }}
+{{ partial "modules/banner" ($.Scratch.Get "course_page") }} 
 
 <div class="grid split2 small-v-padding content">
     <div class="big">
@@ -15,19 +13,18 @@
         <h1 class="no-margin">{{.Title}}</h1>
         {{ with .Params.author }}
             {{ with (index $.Site.Data.authors . ) }}
-            <p>by: {{ .name }} </p>
+            <p>by: {{ .name }}</p>
             {{ end }}
         {{ end }}
     </div>
 </div>
 {{ end }}
 
-
 {{ define "main" }}
 
 {{ $course_page := $.Scratch.Get "course_page" }}
 {{ $.Scratch.Set "pages" $course_page.Pages }}
-{{ $.Scratch.Set "page_index" 0 }}
+{{ $page_index := 0 }}
 
 <div class="grid split2 container">
     <input type="checkbox" name="toc_toggle" id="toc_toggle" class="hidden">
@@ -45,7 +42,8 @@
             <label for="{{.UniqueID}}"><b>{{.Title}}</b></label>
             <ul>
                 {{ range (sort .Pages "Date" "asc") }}
-                {{ if eq . $.Page }} {{ $.Scratch.Set "page_index" ($.Scratch.Get "index") }} {{ end }}
+                {{ if eq . $.Page }} {{ $page_index = ($.Scratch.Get "index") }} {{ end }}
+
                 {{ $.Scratch.Add "pages" . }}
                 {{ $.Scratch.Add "index" 1 }}
 
@@ -59,12 +57,14 @@
 
 
     {{ $pages := $.Scratch.Get "pages" }}
-    {{ $pindex := $.Scratch.Get "page_index" }}
+    {{ $pindex := $page_index }}
+    {{ $prev := -1 }}
+    {{ $next := -1 }}
     {{ if ne $.Page (index (first 1 $pages) 0) }}
-        {{ $.Scratch.Set "prev" (index $pages (sub $pindex 1)) }}
+        {{ $prev = (index $pages (sub $pindex 1)) }}
     {{ end }}
     {{ if ne $.Page (index (last 1 $pages) 0) }}
-        {{ $.Scratch.Set "next" (index $pages (add $pindex 1)) }}
+            {{ $next = (index $pages (add $pindex 1)) }}
     {{ end }}
 
     <article class="base-v-padding big">
@@ -111,11 +111,11 @@
             <div class="big-top-margin">
                 <hr>
                 <div class="flex justify-space-between">
-                    {{ with $.Scratch.Get "prev" }}
-                    <a href="{{.URL}}">Previous</a>
+                    {{ if ne $prev -1 }}
+                    <a href="{{ $prev.URL }}">Previous</a>
                     {{ end }}
-                    {{ with $.Scratch.Get "next" }}
-                    <a href="{{.URL}}">Next</a>
+                    {{ if ne $next -1}}
+                    <a href="{{ $next.URL }}">Next</a>
                     {{ end }}
                 </div>
             </div>


### PR DESCRIPTION
Some of the scratch couldn't be removed for one of two reasons:
1. It was used globally inside the file. If you declare a variable outside a define block, it won't be accessible inside of define blocks.
2. It required .Add to work correctly: couldn't find a work around for this one.

Closes #56