### PR TITLE
Youtube playlist converter script improvements added

### DIFF
--- a/_src/py/youtube_playlists_converter/convert_youtube_playlists_to_webpages.py
+++ b/_src/py/youtube_playlists_converter/convert_youtube_playlists_to_webpages.py
@@ -4,10 +4,26 @@ import requests
 import os
 import shutil
 import re
-import sys
+import argparse, sys
 
-BASE_DIR = "./videos"
-os.makedirs(BASE_DIR, exist_ok=True)
+BASE_DIR = "./playlist"
+VIDEOS_FOLDER = "chapter"
+#os.makedirs(BASE_DIR, exist_ok=True)
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('playlist', help = 'The playlist ID you wish to convert the videos from')
+parser.add_argument('--path', help = 'The absolute path to the website\'s root directory. If none provided, a playlist folder will be created in the root.' )
+parser.add_argument('--folders', metavar='F', type = str, nargs = '+', help = 'Folder structure in which this this series should be placed inside i.e. game-design godot will result in game-design/godot/TITLE')
+parser.add_argument('--force', help = 'Rewrites the path in case it already exists', action = "store_true")
+parser.add_argument('--title', help = 'If left empty, the playlist\'s title will be used as the series\' title.')
+parser.add_argument('--description', help = 'If left empty, the playlist\'s description will be used as the series\' description.')
+
+args = parser.parse_args()
+
+if args.path != None and args.folders == None:
+  print("When using path, you should specify a folder structure using --folders. Use -h for help")
+  sys.exit()
 
 API_KEY = "AIzaSyAUCyzwHmO71chFn7wMa6VlBNzk0tpkFYk"
 CHANNEL_ID = "UCxboW7x0jZqFdvMdCFKTMsQ"
@@ -15,8 +31,13 @@ DOMAIN = "https://content.googleapis.com"
 API = "/youtube/v3"
 BASE_URL = DOMAIN + API
 
+
+#We won't need this playlists array anymore but I kept it here because it seems like it's being used
+#as a history of what has already been added to the website
+
 PLAYLISTS = [
-  "PLhqJJNjsQ7KHqNMYmTwtsYTeTrqrRP_fP",
+  "PLhqJJNjsQ7KEVitqVB9WXfgzcj32Yz-iJ",
+  #"PLhqJJNjsQ7KHqNMYmTwtsYTeTrqrRP_fP",
   # "PLhqJJNjsQ7KEr_YlibZ3SBuzfw9xwGduK",
   # "PLhqJJNjsQ7KEbSXHacP9eD37xyoPJz9gm",
   # "PLhqJJNjsQ7KEtFciikafqWU-OeU4SEejC",
@@ -37,14 +58,71 @@ videoid: {video_id}
 
 """
 
-# get videos in playlist
-for playlist_id in PLAYLISTS:
-  path = os.path.join(BASE_DIR, playlist_id)
-  os.makedirs(path, exist_ok=True)
+series_description_format = """---
+title: '{title}'
+description: {description}
+date: {date}
+author: nathan
 
-  url = "/playlistItems?maxResults=50&part=snippet,contentDetails&key={}&playlistId={}".format(API_KEY, playlist_id)
-  r = requests.get("{}{}".format(BASE_URL, url))
-  videos_data = r.json()
+keywords:
+  - ENTER KEYWORDS
+
+tags:
+  - free
+  - training
+
+type: course
+
+banner:
+    src: banner.png
+
+resources:
+- src: banner.png
+  name: banner
+---
+"""
+
+chapter_description = """---
+author: nathan
+title: ENTER TITLE
+description: ENTER DESCRIPTION
+
+type: course_chapter
+
+weight: 1
+---
+"""
+
+def main():
+  playlist_id = args.playlist
+  
+  playlist_url = "/playlists/?maxResults=25&id={}&part=snippet%2CcontentDetails&key={}".format(playlist_id, API_KEY)
+  playlist_request = requests.get("{}{}".format(BASE_URL, playlist_url))
+  playlist_data = playlist_request.json()
+  
+  playlist_snippet = playlist_data["items"][0]["snippet"]
+  
+  series_title = args.title if args.title != None else playlist_snippet["title"] 
+  path = get_base_path(series_title)
+  print(path)
+  videos_path = os.path.join(path, VIDEOS_FOLDER)
+  create_directories(videos_path)
+
+  with open(os.path.join(videos_path, "_index.md"), "w") as f:
+    f.write(chapter_description)
+
+  series_description = series_description_format.format(
+    date = playlist_snippet["publishedAt"],
+    description = args.description if args.description != None else playlist_snippet["description"].split("\n")[0],
+    title = series_title
+  )
+
+  with open(os.path.join(path, "_index.md"), "w") as f:
+    f.write(series_description)
+
+  url_videos = "/playlistItems?maxResults=50&part=snippet,contentDetails&key={}&playlistId={}".format(API_KEY, playlist_id)
+  video_requests = requests.get("{}{}".format(BASE_URL, url_videos))
+  videos_data = video_requests.json()
 
   for video in videos_data["items"]:
     snippet = video["snippet"]
@@ -52,15 +130,44 @@ for playlist_id in PLAYLISTS:
 
     description = snippet["description"].split("\n")[0]
 
-    pos = snippet["position"]
-    vd = video_file_format.format(
+    position = snippet["position"]
+    video_data = video_file_format.format(
       date=snippet["publishedAt"],
-      weight=pos,
+      weight=position,
       title=snippet["title"],
       description=description,
       video_id=snippet["resourceId"]["videoId"]
     )
 
-    fname = re.sub(r'[-:,/?]|(\[.*\])|(\(.*\))', "", snippet["title"].lower().replace(" ", "_").replace(".", "_"))
-    with open(os.path.join(path, "%s_%s.md" % (pos, fname)), "w") as f:
-      f.write(vd)
+    fname = get_formated_file_name(snippet["title"])
+    with open(os.path.join(videos_path, "%s_%s.md" % (position, fname)), "w") as f:
+      f.write(video_data)
+
+def get_base_path(title):
+  path = ""
+  title = get_formated_file_name(title)
+  if args.path == None:
+    path = os.path.join(BASE_DIR, title)
+  else:
+    path = os.path.join(args.path, 'content\\tutorial\\')
+    folders = ""
+    for folder in args.folders:
+      folders += folder + '\\'
+    path = os.path.join(path, folders)
+    path = os.path.join(path, title)
+  return path
+
+def create_directories(path):
+  if args.force:
+    os.makedirs(path, exist_ok=True)
+  else:
+    try:
+      os.makedirs(path)
+    except:
+      print("The provided path already exists, if you'd like to rewrite it, use --force. Use -h for help")
+      sys.exit()
+
+def get_formated_file_name(name):
+  return re.sub(r'[-:,/?]|(\[.*\])|(\(.*\))', "", name.lower().replace(" ", "_").replace(".", "_"))
+
+main()


### PR DESCRIPTION
It's now possible to use options when calling the script through the CLI. Use --help to find the full list with descriptions.

### How to use

The previous behavior of the script is still somewhat present. Just call
the script like so:
```bash
$ python convert_youube_playlists_to_webpages <PLAYLIST_ID>
```
and it will create a single folder at the root of the script's project with the new files.

To create a playlist in the correct folder inside the website project, use:
```bash
$ python convert_youtube_playlists_to_webpages.py <PLAYLIST_ID> --path "C:\!GDQuest\Repos\forks\GDquest-website\" --folders "game-design" "godot"
```

This will create a folder with the name of the playlist inside of `content/tutorial/game-design/godot`

All of what's left then is to fill in the information inside the indexes of both the chapter and the series.

If you'd like to overwrite the description of the youtube playlist and name, you can use `--description` and `--title` respectively. Both the name of the folder created and the description/title inside of the `_index.md` will reflect these options.

Lastely, you can use `--force` to force the script to overwrite existing folders. The behavior before was to always overwrite, but since now we may create folders inside the content folder I thought this would lead to problems, so I changed it.

### Suggestions

I'm open to suggestions on what could be improved in this new approach for the script. This is my first CLI tool and I'm not complete aware of good practices when it comes to these kinds of tools 😃 

Closes #65