### PR TITLE
Improve the shortcuts template styles

### DIFF
--- a/layouts/partials/keystroke.html
+++ b/layouts/partials/keystroke.html
@@ -1,13 +1,13 @@
 {{ $character_map := (dict "ONE" "1" "TWO" "2" "THREE" "3" "FOUR" "4" "FIVE" "5" "SIX" "6" "SEVEN" "7" "EIGHT" "8" "NINE" "9" "ZERO" "0" "PLUS" "+" "UP_ARROW" "↑" "DOWN_ARROW" "↓" "LEFT_ARROW" "←" "RIGHT_ARROW" "→" "LEFT_BRACKET" "[" "RIGHT_BRACKET" "]" "LEFTMOUSE" "LMB" "RIGHTMOUSE" "RMB") }}
 
 <span class="keystroke">
-    {{ with .ctrl }}<code>Ctrl</code>{{ end }}
-    {{ with .alt }}<code>Alt</code>{{ end }}
-    {{ with .shift }}<code>Shift</code>{{ end }}
+    {{ with .ctrl }}<kbd>Ctrl</kbd>{{ end }}
+    {{ with .alt }}<kbd>Alt</kbd>{{ end }}
+    {{ with .shift }}<kbd>Shift</kbd>{{ end }}
 
     {{ if isset $character_map .type }}
-    <code>{{ index $character_map .type }}</code>
+    <kbd>{{ index $character_map .type }}</kbd>
     {{ else }}
-    <code>{{ .type }}</code>
+    <kbd>{{ .type }}</kbd>
     {{ end }}
 </span>

--- a/layouts/partials/shortcuts.html
+++ b/layouts/partials/shortcuts.html
@@ -10,14 +10,14 @@
         </ul>
     </nav>
 
-    <div class="shortcuts big">
+    <div class="big">
         {{ range $key, $value := . }}
-        <article id="{{$key}}">
+        <article id="{{$key}}" class="operator">
             <h5>{{$value.name}}</h5>
-            <p>{{ strings.TrimPrefix "*brief* " $value.description | markdownify }}</p>
-            <p>
-                {{ with index $value.demo }} <img src="{{.}}" alt=""> {{ end }}
-            </p>
+            {{ strings.TrimPrefix "*brief* " $value.description | markdownify }}
+            {{ with $value.demo }}
+                <p><img src="{{.}}" alt=""></p>
+            {{ end }}
 
             <!-- Shortcut JSON example: -->
             <!-- "shortcuts": [

--- a/layouts/partials/shortcuts.html
+++ b/layouts/partials/shortcuts.html
@@ -24,14 +24,17 @@
                 [{"type": "X", "value": "PRESS"}, {}, "Delete Direct"],
                 [{"type": "DEL", "value": "PRESS"}, {}, "Delete Direct"]
             ]-->
-            {{ range $value.shortcuts }}
-            <div class="shortcut">
-                <div>
-                    {{ $shortcut := (index . 0) }}
-                    {{ partial "keystroke.html" $shortcut }}
-                    <span>{{ index . 2 }}</span>
-                </div>
-            </div>
+            {{ with $value.shortcuts }}
+            <table class="shortcuts">
+                <tbody>
+                    {{ range . }}
+                    <tr>
+                        <td>{{ partial "keystroke.html" (index . 0) }}</td>
+                        <td>{{ index . 2 }}</td>
+                    </tr>
+                    {{ end }}
+                </tbody>
+            </table>
             {{ end }}
         </article>
         {{ end }}

--- a/resources/scss/modules/_shortcuts.scss
+++ b/resources/scss/modules/_shortcuts.scss
@@ -1,5 +1,13 @@
-.shortcuts>section {
-    margin-bottom: $spacing-big;
+.operator {
+    padding: $spacing-base 0;
+
+    +.operator {
+        border-top: 2px solid $base-border-color;
+    }
+
+    >h5 {
+        margin-top: 0;
+    }
 }
 
 .shortcuts {

--- a/resources/scss/modules/_shortcuts.scss
+++ b/resources/scss/modules/_shortcuts.scss
@@ -24,11 +24,10 @@
     }
 }
 
-.keystroke {
-    code {
-        border: 2px solid $color-default-text;
-        padding: $spacing-micro / 2 $spacing-micro;
-        border-radius: 4px;
-        display: inline-block;
-    }
+.keystroke>kbd {
+    border: 2px solid $color-default-text;
+    padding: $spacing-micro / 4 $spacing-micro;
+    border-radius: $round-radius / 2;
+    display: inline-block;
+    font-family: inherit;
 }

--- a/resources/scss/modules/_shortcuts.scss
+++ b/resources/scss/modules/_shortcuts.scss
@@ -2,25 +2,14 @@
     margin-bottom: $spacing-big;
 }
 
-.shortcut {
-    box-sizing: border-box;
+.shortcuts {
+    border-collapse: separate;
+    border-spacing: $spacing-small $spacing-tiny;
+    margin: 0 (-$spacing-small) (-$spacing-tiny);
 
-    >div {
-        margin-bottom: $spacing-micro;
-        display: flex;
-        align-items: center;
-
-        >:first-child {
-            flex: 1;
-        }
-
-        >:last-child {
-            flex: 1;
-        }
-    }
-
-    img {
-        margin-bottom: $spacing-small;
+    >tbody>tr>td:first-child {
+        width: 0;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
Part of issue #88 
## Screenshot

| Before | After ([Live preview](https://deploy-preview-89--gdquest.netlify.com/blender/power-sequencer/docs/)) |
|--------|------|
| ![grafik](https://user-images.githubusercontent.com/9270901/64176416-b5452a00-ce5d-11e9-955d-b362345cc081.png) | ![grafik](https://user-images.githubusercontent.com/9270901/64176458-cd1cae00-ce5d-11e9-89bf-f969966ce951.png) |



## Visual changes
- divider between operators
- keystroke font is now sans-serif
- description of shortcuts moved closer to the keystrokes

## Code changes
- change `<code>` to `<kbd>` for keystrokes
- remove extra  `<p>` around description (markdown generates them already)
- change css class names and assignment (see comparison below):
  - multiple sibling `div.shortcut` are now one `table.shortcuts`
  - former top-level `div.shortcuts` lost this class (as I used `.shortcuts` for the table), instead the children are now `article.operator`.
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

```html
<div class="shortcuts big">
  <article>
    <h5>...</h5>
    <p><p>...</p></p>
		
    <div class="shortcut">
      <div>
        <code>...</code>
        <span>...</span>
      </div>
    </div>
    <div class="shortcut">
      <div>
        <code>...</code>
        <span>...</span>
      </div>
    </div>
		
  </article>
</div>
```

</td><td>

 ```html
<div class="big">
  <article class="operator">
    <h5>...</h5>
    <p>...</p>
    <table class="shortcuts">

        <tr>
          <td><kbd>...</kbd></td>
          <td>...</td>
        </tr>


        <tr>
          <td><kbd>...</kbd></td>
          <td>...</td>
        </tr>

    </table>
  </article>
</div>
```

</td></tr></table>