### PR TITLE
Sticky sidebar for PS docs

### DIFF
--- a/layouts/partials/shortcuts.html
+++ b/layouts/partials/shortcuts.html
@@ -1,8 +1,8 @@
 {{ with index $.Site.Data.blender.power_sequencer_docs }}
 <section class="grid split2 container">
     <!-- Left column: operators list menu -->
-    <nav class="small">
-        <h3 class="no-margin-top">operators</h3>
+    <nav class="small sticky-nav">
+        <h3>Operators</h3>
         <ul>
             {{ range $key, $value := . }}
             <li> <a href="#{{$key}}">{{ $value.name }}</a></li>

--- a/resources/scss/_base.scss
+++ b/resources/scss/_base.scss
@@ -287,7 +287,6 @@ main {
 
     position: relative;
     padding-bottom: $spacing-huge;
-    overflow: auto;
 
     z-index: 200;
 }

--- a/resources/scss/modules/_shortcuts.scss
+++ b/resources/scss/modules/_shortcuts.scss
@@ -1,3 +1,19 @@
+.sticky-nav {
+    position: sticky;
+    top: 0;
+    max-height: 100vh;
+    overflow-y: auto;
+    padding-right: $spacing-small;
+    
+    >h3 {
+        position: sticky;
+        top: 0;
+        margin: 0;
+        padding: $spacing-small 0;
+        background-image: linear-gradient(to top, transparent, $color-default-base $spacing-small);
+  }
+}
+
 .operator {
     padding: $spacing-base 0;
 


### PR DESCRIPTION
Part of issue #88

Makes the left sidebar sticky and scrollable independent of the rest of the page.
It's not perfect, but the best I could do with simple css styles.

I had to remove the following from the global styles, otherwise the sticky functionality wouldn't work.
```css
main {
    overflow: auto;
}
```

The remaining styles are only targeted at the class `.sticky-nav`. If there is need, this class could be used on other pages, too.