### PR TITLE
Sticky sidebar fixes

### DIFF
--- a/layouts/partials/shortcuts.html
+++ b/layouts/partials/shortcuts.html
@@ -2,12 +2,14 @@
 <section class="grid split2 container">
     <!-- Left column: operators list menu -->
     <nav class="small">
-        <h3 class="sticky-nav-title">Operators</h3>
-        <ul class="sticky-menu">
-            {{ range $key, $value := . }}
-            <li> <a href="#{{$key}}">{{ $value.name }}</a></li>
-            {{ end }}
-        </ul>
+        <div class="sticky-nav">
+            <h3>Operators</h3>
+            <ul>
+                {{ range $key, $value := . }}
+                <li><a href="#{{$key}}">{{ $value.name }}</a></li>
+                {{ end }}
+            </ul>
+        </div>
     </nav>
 
     <div class="big">

--- a/resources/scss/_base.scss
+++ b/resources/scss/_base.scss
@@ -288,6 +288,10 @@ main {
     position: relative;
     padding-bottom: $spacing-huge;
 
+    // prevent collapsing margin
+    padding-top: 1px;
+    margin-top: -1px;
+
     z-index: 200;
 }
 

--- a/resources/scss/modules/_shortcuts.scss
+++ b/resources/scss/modules/_shortcuts.scss
@@ -1,20 +1,14 @@
-/* Sticky list on the left side of the docs, or top on mobile/tablet */
-$sticky-nav-title-height: $font-size-h3 + $spacing-small * 2.0;
-
-.sticky-menu {
-    position: sticky;
-    top: $sticky-nav-title-height;
-    max-height: 90vh;
-    overflow-y: auto;
-    padding-right: $spacing-small;
-}
-
-.sticky-nav-title {
+.sticky-nav {
     position: sticky;
     top: 0;
-    margin: 0;
-    z-index: 100;
-    padding: $spacing-small 0;
+    max-height: 100vh;
+    display: flex;
+    flex-direction: column;
+
+    >ul {
+        overflow-y: auto;
+        padding-right: $spacing-small;
+    }
 }
 
 .operator {


### PR DESCRIPTION
This PR contains two fixes related to the sticky sidebar

### 1.
Cleaner styles for the sticky sidebar, using flexbox to distribute the available space between heading and scrollable list.
Previous solution had `$font-size-h3 + $spacing-small * 2.0 + 90vh`, which may or may not add up to 100% height. Furthermore, the sticky heading would overlap the links when scrolled to far down.

Since the `nav` container itself is not sticky (but a nested `div` instead), it still works on mobile devices / small screens.

### 2. 
Removing `main {overflow: auto}` introduced a black box on the frontpage.
This rule had prevented collapsing margins (and thus the black box), but also the stickieness of the sidebar. [Stackoverflow has more infos about that.](https://stackoverflow.com/questions/1762539/margin-on-child-element-moves-parent-element)
This is now fixed by adding a `1px` padding, which is neutralized by `-1px` margin.