### PR TITLE
CSS fixes for IE

### DIFF
--- a/resources/scss/_base.scss
+++ b/resources/scss/_base.scss
@@ -282,6 +282,7 @@ a:hover .icon {
 }
 
 main {
+    display: block; // needed for IE
     background-color: $color-default-base;
     color: $color-default-text;
 

--- a/resources/scss/modules/_shortcuts.scss
+++ b/resources/scss/modules/_shortcuts.scss
@@ -1,13 +1,14 @@
 .sticky-nav {
     position: sticky;
     top: 0;
-    max-height: 100vh;
+    height: 100vh;
     display: flex;
     flex-direction: column;
 
     >ul {
         overflow-y: auto;
         padding-right: $spacing-small;
+        flex: 0 1 auto; // needed for IE 10
     }
 }
 


### PR DESCRIPTION
Small fixes so that the page looks better (still not perfect) in IE.

- IE doesn't know that `main` should be `display: block`, which resulted in a black page background.
- Flexbox shrinking doesn't work with `min-height`, so I changed it to `height`.
- IE 10 has a different default value for `flex: 0 1 auto;`, which also prevented shrinking the navbar.